### PR TITLE
ci: 🎡 run github-agent CLI with model argument

### DIFF
--- a/.github/workflows/discussions-issue.yml
+++ b/.github/workflows/discussions-issue.yml
@@ -40,4 +40,4 @@ jobs:
           MODE: "prod"
         run: |
           echo '${{ toJson(github.event) }}' > payload.json
-          cat payload.json
+          node github-agent/dist/cli.js payload.json --model 1


### PR DESCRIPTION
- Updated `.github/workflows/discussions-issue.yml` to execute `github-agent/dist/cli.js` instead of simply printing payloads
- Added `--model 1` argument to pass model configuration to the agent
- Updated `github-agent` submodule to latest commit `d0d254d`